### PR TITLE
Putting test dependencies in maven test scope.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.cronitor</groupId>
     <artifactId>client</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.1</version>
     <name>Cronitor Client</name>
     <description>cronitor-client is a simple Java library designed to help you monitoring, with www.cronitor.io, the routines of your Java projects</description>
     <url>https://github.com/cronitorio/cronitor-java</url>
@@ -55,11 +55,17 @@
             <artifactId>httpclient</artifactId>
             <version>4.5.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.9</version>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.hamcrest</groupId>
@@ -71,27 +77,25 @@
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <version>1.3</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>2.18.0</version>
-          </dependency>
-
-          <dependency>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
             <version>2.0.0</version>
-          </dependency>
-          <dependency>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
             <version>2.0.0</version>
-          </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.4</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Incrementing main pom version to 1.4.1

Test dependencies should be in maven test scope. Otherwise any project having cronitor as a dependency can have conflicts with it's own JUnit test dependencies.